### PR TITLE
Parse `OPERATOR` as Vec<String>

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -33,7 +33,7 @@ pub use self::ddl::{
     AlterColumnOperation, AlterTableOperation, ColumnDef, ColumnOption, ColumnOptionDef,
     ReferentialAction, TableConstraint,
 };
-pub use self::operator::{BinaryOperator, PGCustomOperator, UnaryOperator};
+pub use self::operator::{BinaryOperator, UnaryOperator};
 pub use self::query::{
     Cte, Fetch, Join, JoinConstraint, JoinOperator, LateralView, LockType, Offset, OffsetRows,
     OrderByExpr, Query, Select, SelectInto, SelectItem, SetExpr, SetOperator, TableAlias,


### PR DESCRIPTION
Re https://github.com/sqlparser-rs/sqlparser-rs/pull/548/files

Here is a proposed alternative (targeting your branch) that represents a PG custom operator using `Vec<String>` of the raw token streams and demonstrating it is more general